### PR TITLE
Add GH_TOKEN to update-course action

### DIFF
--- a/.github/workflows/update-courses.yml
+++ b/.github/workflows/update-courses.yml
@@ -29,6 +29,8 @@ jobs:
         run: npx tsx scripts/update-courses.ts
 
       - name: Commit and push changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'


### PR DESCRIPTION
I will need to add a token as a secret to the repo, but this should allow GH commands to be used in the action so it stops failing.