### PR TITLE
Change GH_TOKEN used to a new PAT for PR creation in update_courses.yml

### DIFF
--- a/.github/workflows/update-courses.yml
+++ b/.github/workflows/update-courses.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Commit and push changes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WIKI_PAT }}
         run: |
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'


### PR DESCRIPTION
A new PAT was created and added as a repo secret called `WIKI_PAT`. This PR enables that PAT to be used by `update_courses.yml` so that when it creates a PR, the build workflows are run.