### PR TITLE
Remove gitignore path from format check so .prettierignore is respected

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "npm run generate-metadata && next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --check --ignore-path .gitignore .",
-    "format:fix": "prettier --write --ignore-path .gitignore .",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
Currently `npm run format` runs `prettier --check --ignore-paths .gitignore .`. This forces prettier to ignore the `.prettierignore` file in the repo, and serves no purpose because prettier already ignores `.gitignore` by default.

This PR supports #27 because it allows that PR to include `data/CourseInfoData.ts` in `.prettierignore`, which will allow it to pass the CI checks. We shouldn't care about the formatting of an auto-generated file anyway, so this is fine.