### PR TITLE
Fix stale GitHub repository links

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -27,7 +27,7 @@ export default function AboutPage() {
           <Link href="/feedback">filling out this form!</Link> If you are
           interested in the technical details of the wiki, everything is open
           source and documented on{" "}
-          <a href="https://github.com/pittcsc/pittcswiki-next" target="_none">
+          <a href="https://github.com/pittcsc/pittcs-wiki" target="_none">
             the GitHub repo!
           </a>
         </p>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -47,7 +47,7 @@ const Footer = (): JSX.Element => {
             Feedback
           </Link>
           <Link
-            href="https://github.com/pittcsc/pittcswiki-next"
+            href="https://github.com/pittcsc/pittcs-wiki"
             target="_blank"
             className="text-gray-600 dark:text-gray-300 hover:text-[#FFB81C] transition-colors duration-200"
           >


### PR DESCRIPTION
Fixes #18.

This updates the stale GitHub repository URL in the footer from `pittcswiki-next` to the current `pittcs-wiki` repository. I also updated the matching About page repository link so the site no longer points users to the old repo from either public page.

Validation:
- `npm test -- --runInBand` passes: 1 test suite, 1 test
- `prettier --check app/about/page.tsx components/Footer.tsx` passes
- `git diff --check` passes

Note: the repo-wide `npm run format` currently reports many pre-existing formatting warnings outside these touched files, so I scoped formatting verification to the changed files.