### PR TITLE
Issue - fix edit on GitHub link in footer and Repo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern, community-driven knowledge platform for University of Pittsburgh Computer Science students. This resource provides comprehensive guides on academics, careers, technical skills, and student life.
 
-**[Live Website](https://pittcs.wiki)** | **[Report Issues](https://github.com/pittcsc/pittcswiki/issues)** | **[Contributing Guide](docs/contributing.md)**
+**[Live Website](https://pittcs.wiki)** | **[Report Issues](https://github.com/pittcsc/pittcs-wiki/issues)** | **[Contributing Guide](docs/contributing.md)**
 
 ## About
 
@@ -34,8 +34,8 @@ Rebuilt from the ground up with modern tools for better maintainability, perform
 
 ```bash
 # Clone the repository
-git clone https://github.com/pittcsc/pittcswiki.git
-cd pittcswiki
+git clone https://github.com/pittcsc/pittcs-wiki.git
+cd pittcs-wiki
 
 # Install dependencies
 npm install
@@ -119,6 +119,6 @@ This project is open source and available under the MIT License.
 
 ## Contact & Support
 
-- **Questions or Ideas?** [Open a GitHub Issue](https://github.com/pittcsc/pittcswiki/issues)
+- **Questions or Ideas?** [Open a GitHub Issue](https://github.com/pittcsc/pittcs-wiki/issues)
 - **Reach Out**: [PittCSC@gmail.com](mailto:PittCSC@gmail.com)
 - **Original Wiki**: [Legacy Repository](https://github.com/pittcsc/pittcswiki-next)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern, community-driven knowledge platform for University of Pittsburgh Computer Science students. This resource provides comprehensive guides on academics, careers, technical skills, and student life.
 
-**[Live Website](https://pittcs.wiki)** | **[Report Issues](https://github.com/pittcsc/pittcswiki-next/issues)** | **[Contributing Guide](docs/contributing.md)**
+**[Live Website](https://pittcs.wiki)** | **[Report Issues](https://github.com/pittcsc/pittcswiki/issues)** | **[Contributing Guide](docs/contributing.md)**
 
 ## About
 
@@ -34,8 +34,8 @@ Rebuilt from the ground up with modern tools for better maintainability, perform
 
 ```bash
 # Clone the repository
-git clone https://github.com/pittcsc/pittcswiki-next.git
-cd pittcswiki-next
+git clone https://github.com/pittcsc/pittcswiki.git
+cd pittcswiki
 
 # Install dependencies
 npm install
@@ -119,6 +119,6 @@ This project is open source and available under the MIT License.
 
 ## Contact & Support
 
-- **Questions or Ideas?** [Open a GitHub Issue](https://github.com/pittcsc/pittcswiki-next/issues)
+- **Questions or Ideas?** [Open a GitHub Issue](https://github.com/pittcsc/pittcswiki/issues)
 - **Reach Out**: [PittCSC@gmail.com](mailto:PittCSC@gmail.com)
-- **Original Wiki**: [Legacy Repository](https://github.com/pittcsc/pittcswiki)
+- **Original Wiki**: [Legacy Repository](https://github.com/pittcsc/pittcswiki-next)

--- a/components/EditOnGithub.tsx
+++ b/components/EditOnGithub.tsx
@@ -1,6 +1,6 @@
 import { EditIcon } from "@/svgs/EditIcon"
 
-const GITHUB_BASE_URL = `https://github.com/pittcsc/pittcswiki-next/blob/main/data/`
+const GITHUB_BASE_URL = `https://github.com/pittcsc/pittcs-wiki/blob/main/data/`
 
 type EditOnGithubProps = {
   slug: string

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,8 +9,8 @@ Thank you for your interest in contributing to the Pitt CS Wiki! We welcome cont
 1. **Fork** the repository on GitHub
 2. **Clone** your fork locally:
    ```bash
-   git clone https://github.com/your-username/pittcswiki-next.git
-   cd pittcswiki-next
+   git clone https://github.com/your-username/pittcswiki.git
+   cd pittcswiki
    ```
 3. **Create a new branch** for your changes:
    ```bash

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,8 +9,8 @@ Thank you for your interest in contributing to the Pitt CS Wiki! We welcome cont
 1. **Fork** the repository on GitHub
 2. **Clone** your fork locally:
    ```bash
-   git clone https://github.com/your-username/pittcswiki.git
-   cd pittcswiki
+   git clone https://github.com/your-username/pittcs-wiki.git
+   cd pittcs-wiki
    ```
 3. **Create a new branch** for your changes:
    ```bash

--- a/public/guide-metadata.json
+++ b/public/guide-metadata.json
@@ -33,12 +33,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Jayden Kelly"
-    ],
-    "updaterEmails": [
-      "jaykelly924@gmail.com"
-    ],
+    "updaters": ["Jayden Kelly"],
+    "updaterEmails": ["jaykelly924@gmail.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1232,
@@ -51,17 +47,13 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Aarash Zakeri",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "ArchZak"
-    ],
-    "updaterEmails": [
-      "izear21@gmail.com"
-    ],
+    "updaters": ["Aarash Zakeri"],
+    "updaterEmails": ["izear21@gmail.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
-    "wordCount": 4737,
+    "wordCount": 4690,
     "readingTime": 24,
-    "commits": 4
+    "commits": 7
   },
   "guide-academics/majors/dnid": {
     "path": "academics/majors/dnid",
@@ -111,10 +103,7 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan",
-      "liambrem"
-    ],
+    "updaters": ["Shreyash Ranjan", "liambrem"],
     "updaterEmails": [
       "56934841+codingshreyash@users.noreply.github.com",
       "liam.e.brem@gmail.com"
@@ -145,10 +134,7 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Joshua Spisak",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan",
-      "liambrem"
-    ],
+    "updaters": ["Shreyash Ranjan", "liambrem"],
     "updaterEmails": [
       "56934841+codingshreyash@users.noreply.github.com",
       "liam.e.brem@gmail.com"
@@ -221,12 +207,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1340,
@@ -239,10 +221,7 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": [
-      "David",
-      "liambrem"
-    ],
+    "updaters": ["David", "liambrem"],
     "updaterEmails": [
       "136610493+dvdzs8@users.noreply.github.com",
       "liam.e.brem@gmail.com"
@@ -259,12 +238,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Nathan Barta",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "liambrem"
-    ],
-    "updaterEmails": [
-      "liam.e.brem@gmail.com"
-    ],
+    "updaters": ["liambrem"],
+    "updaterEmails": ["liam.e.brem@gmail.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 2157,
@@ -305,11 +280,7 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Gordon Lu",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan",
-      "Denys Tsinyk",
-      "liambrem"
-    ],
+    "updaters": ["Shreyash Ranjan", "Denys Tsinyk", "liambrem"],
     "updaterEmails": [
       "56934841+codingshreyash@users.noreply.github.com",
       "denystsinyk@gmail.com",
@@ -327,12 +298,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1888,
@@ -345,12 +312,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 859,
@@ -377,12 +340,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 347,
@@ -395,12 +354,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 209,
@@ -483,10 +438,7 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan",
-      "liambrem"
-    ],
+    "updaters": ["Shreyash Ranjan", "liambrem"],
     "updaterEmails": [
       "56934841+codingshreyash@users.noreply.github.com",
       "liam.e.brem@gmail.com"
@@ -517,12 +469,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 677,
@@ -605,12 +553,8 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": [
-      "liambrem"
-    ],
-    "updaterEmails": [
-      "liam.e.brem@gmail.com"
-    ],
+    "updaters": ["liambrem"],
+    "updaterEmails": ["liam.e.brem@gmail.com"],
     "lastModified": "2026-01-14T21:27:26.000Z",
     "created": "2025-01-14",
     "wordCount": 1188,
@@ -623,12 +567,8 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": [
-      "liambrem"
-    ],
-    "updaterEmails": [
-      "liam.e.brem@gmail.com"
-    ],
+    "updaters": ["liambrem"],
+    "updaterEmails": ["liam.e.brem@gmail.com"],
     "lastModified": "2026-01-14T21:27:26.000Z",
     "created": "2025-01-14",
     "wordCount": 1455,
@@ -641,12 +581,8 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": [
-      "liambrem"
-    ],
-    "updaterEmails": [
-      "liam.e.brem@gmail.com"
-    ],
+    "updaters": ["liambrem"],
+    "updaterEmails": ["liam.e.brem@gmail.com"],
     "lastModified": "2026-01-14T21:27:26.000Z",
     "created": "2025-01-14",
     "wordCount": 1444,
@@ -659,12 +595,8 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": [
-      "liambrem"
-    ],
-    "updaterEmails": [
-      "liam.e.brem@gmail.com"
-    ],
+    "updaters": ["liambrem"],
+    "updaterEmails": ["liam.e.brem@gmail.com"],
     "lastModified": "2026-01-14T22:53:46.000Z",
     "created": "2025-12-17",
     "wordCount": 1614,
@@ -677,12 +609,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 110,
@@ -737,11 +665,7 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Alex Zharichenko",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "braynguyen",
-      "Brayden Nguyen",
-      "Shreyash Ranjan"
-    ],
+    "updaters": ["braynguyen", "Brayden Nguyen", "Shreyash Ranjan"],
     "updaterEmails": [
       "btn16@pitt.edu",
       "112491386+braynguyen@users.noreply.github.com",
@@ -829,12 +753,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1270,
@@ -847,12 +767,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1805,
@@ -865,12 +781,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1726,
@@ -883,12 +795,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1326,
@@ -901,12 +809,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1154,
@@ -919,12 +823,8 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": [
-      "Shreyash Ranjan"
-    ],
-    "updaterEmails": [
-      "56934841+codingshreyash@users.noreply.github.com"
-    ],
+    "updaters": ["Shreyash Ranjan"],
+    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 318,

--- a/public/guide-metadata.json
+++ b/public/guide-metadata.json
@@ -33,8 +33,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Jayden Kelly"],
-    "updaterEmails": ["jaykelly924@gmail.com"],
+    "updaters": [
+      "Jayden Kelly"
+    ],
+    "updaterEmails": [
+      "jaykelly924@gmail.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1232,
@@ -47,13 +51,17 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Aarash Zakeri",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Aarash Zakeri"],
-    "updaterEmails": ["izear21@gmail.com"],
+    "updaters": [
+      "ArchZak"
+    ],
+    "updaterEmails": [
+      "izear21@gmail.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
-    "wordCount": 4690,
+    "wordCount": 4737,
     "readingTime": 24,
-    "commits": 7
+    "commits": 4
   },
   "guide-academics/majors/dnid": {
     "path": "academics/majors/dnid",
@@ -103,7 +111,10 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan", "liambrem"],
+    "updaters": [
+      "Shreyash Ranjan",
+      "liambrem"
+    ],
     "updaterEmails": [
       "56934841+codingshreyash@users.noreply.github.com",
       "liam.e.brem@gmail.com"
@@ -134,7 +145,10 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Joshua Spisak",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan", "liambrem"],
+    "updaters": [
+      "Shreyash Ranjan",
+      "liambrem"
+    ],
     "updaterEmails": [
       "56934841+codingshreyash@users.noreply.github.com",
       "liam.e.brem@gmail.com"
@@ -207,8 +221,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1340,
@@ -221,7 +239,10 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": ["David", "liambrem"],
+    "updaters": [
+      "David",
+      "liambrem"
+    ],
     "updaterEmails": [
       "136610493+dvdzs8@users.noreply.github.com",
       "liam.e.brem@gmail.com"
@@ -238,8 +259,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Nathan Barta",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["liambrem"],
-    "updaterEmails": ["liam.e.brem@gmail.com"],
+    "updaters": [
+      "liambrem"
+    ],
+    "updaterEmails": [
+      "liam.e.brem@gmail.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 2157,
@@ -280,7 +305,11 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Gordon Lu",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan", "Denys Tsinyk", "liambrem"],
+    "updaters": [
+      "Shreyash Ranjan",
+      "Denys Tsinyk",
+      "liambrem"
+    ],
     "updaterEmails": [
       "56934841+codingshreyash@users.noreply.github.com",
       "denystsinyk@gmail.com",
@@ -298,8 +327,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1888,
@@ -312,8 +345,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 859,
@@ -340,8 +377,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 347,
@@ -354,8 +395,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 209,
@@ -438,7 +483,10 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan", "liambrem"],
+    "updaters": [
+      "Shreyash Ranjan",
+      "liambrem"
+    ],
     "updaterEmails": [
       "56934841+codingshreyash@users.noreply.github.com",
       "liam.e.brem@gmail.com"
@@ -469,8 +517,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 677,
@@ -553,8 +605,12 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": ["liambrem"],
-    "updaterEmails": ["liam.e.brem@gmail.com"],
+    "updaters": [
+      "liambrem"
+    ],
+    "updaterEmails": [
+      "liam.e.brem@gmail.com"
+    ],
     "lastModified": "2026-01-14T21:27:26.000Z",
     "created": "2025-01-14",
     "wordCount": 1188,
@@ -567,8 +623,12 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": ["liambrem"],
-    "updaterEmails": ["liam.e.brem@gmail.com"],
+    "updaters": [
+      "liambrem"
+    ],
+    "updaterEmails": [
+      "liam.e.brem@gmail.com"
+    ],
     "lastModified": "2026-01-14T21:27:26.000Z",
     "created": "2025-01-14",
     "wordCount": 1455,
@@ -581,8 +641,12 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": ["liambrem"],
-    "updaterEmails": ["liam.e.brem@gmail.com"],
+    "updaters": [
+      "liambrem"
+    ],
+    "updaterEmails": [
+      "liam.e.brem@gmail.com"
+    ],
     "lastModified": "2026-01-14T21:27:26.000Z",
     "created": "2025-01-14",
     "wordCount": 1444,
@@ -595,8 +659,12 @@
     "authorEmail": "56934841+codingshreyash@users.noreply.github.com",
     "originalAuthor": "Shreyash Ranjan",
     "originalAuthorEmail": "56934841+codingshreyash@users.noreply.github.com",
-    "updaters": ["liambrem"],
-    "updaterEmails": ["liam.e.brem@gmail.com"],
+    "updaters": [
+      "liambrem"
+    ],
+    "updaterEmails": [
+      "liam.e.brem@gmail.com"
+    ],
     "lastModified": "2026-01-14T22:53:46.000Z",
     "created": "2025-12-17",
     "wordCount": 1614,
@@ -609,8 +677,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 110,
@@ -665,7 +737,11 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Alex Zharichenko",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["braynguyen", "Brayden Nguyen", "Shreyash Ranjan"],
+    "updaters": [
+      "braynguyen",
+      "Brayden Nguyen",
+      "Shreyash Ranjan"
+    ],
     "updaterEmails": [
       "btn16@pitt.edu",
       "112491386+braynguyen@users.noreply.github.com",
@@ -753,8 +829,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1270,
@@ -767,8 +847,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1805,
@@ -781,8 +865,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1726,
@@ -795,8 +883,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1326,
@@ -809,8 +901,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 1154,
@@ -823,8 +919,12 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Steven Jarmell",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Shreyash Ranjan"],
-    "updaterEmails": ["56934841+codingshreyash@users.noreply.github.com"],
+    "updaters": [
+      "Shreyash Ranjan"
+    ],
+    "updaterEmails": [
+      "56934841+codingshreyash@users.noreply.github.com"
+    ],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
     "wordCount": 318,


### PR DESCRIPTION
Fixes #18 - edit on Github links to wrong repository. Also fixes a few links in the README.md and Contributing.md that reference github.com/pitcsc/pittcswiki-next instead of github.com/pittcsc/pittcs-wiki.