### PR TITLE
Fix old GitHub links

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -27,7 +27,7 @@ export default function AboutPage() {
           <Link href="/feedback">filling out this form!</Link> If you are
           interested in the technical details of the wiki, everything is open
           source and documented on{" "}
-          <a href="https://github.com/pittcsc/pittcs-wiki" target="_none">
+          <a href="https://github.com/pittcsc/pittcswiki-next" target="_none">
             the GitHub repo!
           </a>
         </p>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -27,7 +27,7 @@ export default function AboutPage() {
           <Link href="/feedback">filling out this form!</Link> If you are
           interested in the technical details of the wiki, everything is open
           source and documented on{" "}
-          <a href="https://github.com/pittcsc/pittcswiki-next" target="_none">
+          <a href="https://github.com/pittcsc/pittcs-wiki" target="_none">
             the GitHub repo!
           </a>
         </p>

--- a/app/guides/[...path]/page.tsx
+++ b/app/guides/[...path]/page.tsx
@@ -10,7 +10,6 @@ import rehypeRaw from "rehype-raw"
 import { GetFolderInformation } from "@/utils/guides-page-helper"
 import { getGuideStatus } from "@/config/newGuides"
 import { loadGuideMetadataServer, GuideMetadata } from "@/utils/guide-metadata"
- 
 
 export type FileTitlesType = {
   title: string
@@ -35,7 +34,6 @@ export default async function GuidePage({
   // Try to render as a file (with .md or .mdx extension)
   let curFile = null
   let actualFilePath = curPath
-
 
   // If path doesn't already have an extension, try both .md and .mdx
   if (!curPath.includes(".md")) {

--- a/app/guides/[...path]/page.tsx
+++ b/app/guides/[...path]/page.tsx
@@ -86,6 +86,7 @@ export default async function GuidePage({
     } catch (error) {
       console.error("Error loading guide metadata:", error)
     }
+
     return (
       <WikiArticle
         file={curFile}

--- a/app/guides/[...path]/page.tsx
+++ b/app/guides/[...path]/page.tsx
@@ -10,6 +10,14 @@ import rehypeRaw from "rehype-raw"
 import { GetFolderInformation } from "@/utils/guides-page-helper"
 import { getGuideStatus } from "@/config/newGuides"
 import { loadGuideMetadataServer, GuideMetadata } from "@/utils/guide-metadata"
+ 
+import dynamic from "next/dynamic"
+import ElectivesRankingTable from "@/components/ElectivesRankingTable"
+
+const PrereqGraph = dynamic(() => import("@/components/Graph/PrereqGraph"), {
+  ssr: false,
+  loading: () => <p>Loading graph...</p>,
+})
 
 export type FileTitlesType = {
   title: string
@@ -35,6 +43,7 @@ export default async function GuidePage({
   let curFile = null
   let actualFilePath = curPath
 
+
   // If path doesn't already have an extension, try both .md and .mdx
   if (!curPath.includes(".md")) {
     const mdPath = path.resolve(safeBasePath, curPath + ".md")
@@ -44,7 +53,7 @@ export default async function GuidePage({
     try {
       if ((await fs.stat(mdPath)).isFile()) {
         curFile = await fs.readFile(mdPath, "utf-8")
-        actualFilePath = curPath + ".md"
+        actualFilePath = curPath 
       }
     } catch (e) {
       // File doesn't exist, continue
@@ -55,7 +64,7 @@ export default async function GuidePage({
       try {
         if ((await fs.stat(mdxPath)).isFile()) {
           curFile = await fs.readFile(mdxPath, "utf-8")
-          actualFilePath = curPath + ".mdx"
+          actualFilePath = curPath
         }
       } catch (e) {
         // File doesn't exist, continue to folder logic
@@ -86,7 +95,44 @@ export default async function GuidePage({
     } catch (error) {
       console.error("Error loading guide metadata:", error)
     }
+    if(actualFilePath==="academics/scheduling.mdx") {
+      return (
+          <>
+        <WikiArticle
+          file={curFile}
+          path={"guides/" + curPath}
+          frontmatter={fileFrontMatter}
+          gitAuthorTime=""
+          lastUpdatedString=""
+          metadata={metadata}
+        />
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <div className="mb-12">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
+              CSC&apos;s highly subjective CS Electives Difficulty Ranking
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 max-w-3xl mb-6">
+              These rankings are incredibly subjective and difficulty varies
+              more by professor rather than course.
+            </p>
+            <ElectivesRankingTable />
+          </div>
 
+          <div className="mb-8">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
+              Course Prerequisite Graph
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 max-w-3xl">
+              Visualize the relationships between courses. Solid lines represent
+              prerequisites (must take before), and dashed yellow lines
+              represent corequisites (must take together or before).
+            </p>
+          </div>
+          <PrereqGraph />
+        </div>
+      </>
+      )
+    }
     return (
       <WikiArticle
         file={curFile}

--- a/app/guides/[...path]/page.tsx
+++ b/app/guides/[...path]/page.tsx
@@ -95,44 +95,6 @@ export default async function GuidePage({
     } catch (error) {
       console.error("Error loading guide metadata:", error)
     }
-    if(actualFilePath==="academics/scheduling.mdx") {
-      return (
-          <>
-        <WikiArticle
-          file={curFile}
-          path={"guides/" + curPath}
-          frontmatter={fileFrontMatter}
-          gitAuthorTime=""
-          lastUpdatedString=""
-          metadata={metadata}
-        />
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="mb-12">
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
-              CSC&apos;s highly subjective CS Electives Difficulty Ranking
-            </h2>
-            <p className="text-gray-600 dark:text-gray-400 max-w-3xl mb-6">
-              These rankings are incredibly subjective and difficulty varies
-              more by professor rather than course.
-            </p>
-            <ElectivesRankingTable />
-          </div>
-
-          <div className="mb-8">
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
-              Course Prerequisite Graph
-            </h2>
-            <p className="text-gray-600 dark:text-gray-400 max-w-3xl">
-              Visualize the relationships between courses. Solid lines represent
-              prerequisites (must take before), and dashed yellow lines
-              represent corequisites (must take together or before).
-            </p>
-          </div>
-          <PrereqGraph />
-        </div>
-      </>
-      )
-    }
     return (
       <WikiArticle
         file={curFile}

--- a/app/guides/[...path]/page.tsx
+++ b/app/guides/[...path]/page.tsx
@@ -46,7 +46,7 @@ export default async function GuidePage({
     try {
       if ((await fs.stat(mdPath)).isFile()) {
         curFile = await fs.readFile(mdPath, "utf-8")
-        actualFilePath = curPath 
+        actualFilePath = curPath + ".md"
       }
     } catch (e) {
       // File doesn't exist, continue
@@ -57,7 +57,7 @@ export default async function GuidePage({
       try {
         if ((await fs.stat(mdxPath)).isFile()) {
           curFile = await fs.readFile(mdxPath, "utf-8")
-          actualFilePath = curPath
+          actualFilePath = curPath + ".mdx"
         }
       } catch (e) {
         // File doesn't exist, continue to folder logic

--- a/app/guides/[...path]/page.tsx
+++ b/app/guides/[...path]/page.tsx
@@ -11,13 +11,6 @@ import { GetFolderInformation } from "@/utils/guides-page-helper"
 import { getGuideStatus } from "@/config/newGuides"
 import { loadGuideMetadataServer, GuideMetadata } from "@/utils/guide-metadata"
  
-import dynamic from "next/dynamic"
-import ElectivesRankingTable from "@/components/ElectivesRankingTable"
-
-const PrereqGraph = dynamic(() => import("@/components/Graph/PrereqGraph"), {
-  ssr: false,
-  loading: () => <p>Loading graph...</p>,
-})
 
 export type FileTitlesType = {
   title: string

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -47,7 +47,7 @@ const Footer = (): JSX.Element => {
             Feedback
           </Link>
           <Link
-            href="https://github.com/pittcsc/pittcswiki-next"
+            href="https://github.com/pittcsc/pittcs-wiki"
             target="_blank"
             className="text-gray-600 dark:text-gray-300 hover:text-[#FFB81C] transition-colors duration-200"
           >


### PR DESCRIPTION
The about page and footer on most pages still linked to the legacy github repository. This change fixes those two links and all should be correct now. 
``` npm run lint ``` Has no issues