### PR TITLE
Issue/fix scheduling page

### DIFF
--- a/app/guides/[...path]/page.tsx
+++ b/app/guides/[...path]/page.tsx
@@ -150,7 +150,9 @@ export default async function GuidePage({
                   guideSlug = guideSlug.replace(/\.(md|mdx)$/, "")
                   const categorySlug = curPath.split("/").pop() || ""
                   const guideStatus = getGuideStatus(categorySlug, guideSlug)
-
+                  if (file.href.includes(".")) {
+                    file.href = file.href.substring(0, file.href.indexOf("."))
+                  }
                   return (
                     <div key={i} className="guide-card-container">
                       <a

--- a/components/SiteMapList.tsx
+++ b/components/SiteMapList.tsx
@@ -141,12 +141,13 @@ const SiteMapList = ({ type }: any) => {
           getPagesUnderRoute(baseDirectory, relativeFilePath, newNode)
         } else if (!file.name.endsWith("index.md")) {
           const fullFilePath = path.join(baseDirectory, relativeFilePath)
+          const newRelativeFilePath = relativeFilePath.replace(/\.(md|mdx)$/, "")
           const contents = fs.readFileSync(fullFilePath, { encoding: "utf8" })
           const guideData = getMDFrontMatter(contents)
 
           let newNode: SiteMapTree = {
             title: guideData.title,
-            href: relativeFilePath,
+            href: newRelativeFilePath,
             id: id++,
             children: [],
           }

--- a/components/SiteMapList.tsx
+++ b/components/SiteMapList.tsx
@@ -141,7 +141,10 @@ const SiteMapList = ({ type }: any) => {
           getPagesUnderRoute(baseDirectory, relativeFilePath, newNode)
         } else if (!file.name.endsWith("index.md")) {
           const fullFilePath = path.join(baseDirectory, relativeFilePath)
-          const newRelativeFilePath = relativeFilePath.replace(/\.(md|mdx)$/, "")
+          const newRelativeFilePath = relativeFilePath.replace(
+            /\.(md|mdx)$/,
+            ""
+          )
           const contents = fs.readFileSync(fullFilePath, { encoding: "utf8" })
           const guideData = getMDFrontMatter(contents)
 

--- a/public/guide-metadata.json
+++ b/public/guide-metadata.json
@@ -47,13 +47,13 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Aarash Zakeri",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["ArchZak"],
+    "updaters": ["Aarash Zakeri"],
     "updaterEmails": ["izear21@gmail.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
-    "wordCount": 4737,
+    "wordCount": 4690,
     "readingTime": 24,
-    "commits": 4
+    "commits": 7
   },
   "guide-academics/majors/dnid": {
     "path": "academics/majors/dnid",

--- a/public/guide-metadata.json
+++ b/public/guide-metadata.json
@@ -47,13 +47,13 @@
     "authorEmail": "sjj27@pitt.edu",
     "originalAuthor": "Aarash Zakeri",
     "originalAuthorEmail": "sjj27@pitt.edu",
-    "updaters": ["Aarash Zakeri"],
+    "updaters": ["ArchZak"],
     "updaterEmails": ["izear21@gmail.com"],
     "lastModified": "2023-11-28T19:56:49.000Z",
     "created": "2023-11-28T19:56:49.000Z",
-    "wordCount": 4690,
+    "wordCount": 4737,
     "readingTime": 24,
-    "commits": 7
+    "commits": 4
   },
   "guide-academics/majors/dnid": {
     "path": "academics/majors/dnid",


### PR DESCRIPTION
Should fix #39, but needs a look over. Now all cards in guides sections route without the .md/.mdx extension, so that pages like the scheduling one can render typescript in them (ULE tier list). Also, I applied this change to the sitemap. All links should be more uniform on the page now.