### PR TITLE
Feature: reroute md files

### DIFF
--- a/enums/CSLegendData.ts
+++ b/enums/CSLegendData.ts
@@ -5,7 +5,7 @@ export const CSLegendData: { [course: string]: string } = {
   CS0445: "#2196f3", // blue
   CS1501: "#00838f", //dark blue
   CS0449: "#4caf50", // green
-  CS1550: "#673ab7", // purple
+  CS1503: "#673ab7", // purple
   OTHER: "#47494c", // gray
   // insert joke about how ming is a cs legend
 }

--- a/next.config.js
+++ b/next.config.js
@@ -37,7 +37,7 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: "/:slug*/:file((?<!index)\\S+).md(\\w*)",
+        source: "/:slug*/:file(\\S+).md(\\w*)",
         destination: "/:slug*/:file",
         permanent: true,
       },

--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,15 @@ const nextConfig = {
   experimental: {
     // webpackBuildWorker: true,
   },
+  async redirects() {
+    return [
+      {
+        source: "/:slug*/:file((?<!index)\\S+).md(\\w*)",
+        destination: "/:slug*/:file",
+        permanent: true,
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Adds regex matching to next.config to reroute when accessing files ending with .md or .mdx to remove the file extension. 

Also fixes an enum that was making the organization of the courses page off, since it still considered CS1550 a core course.